### PR TITLE
Symbolize and freeze values when loading from JSON

### DIFF
--- a/lib/i18n/backend/base.rb
+++ b/lib/i18n/backend/base.rb
@@ -255,7 +255,7 @@ module I18n
         # toplevel keys.
         def load_json(filename)
           begin
-            ::JSON.parse(File.read(filename))
+            ::JSON.parse(File.read(filename), symbolize_names: true, freeze: true)
           rescue TypeError, StandardError => e
             raise InvalidLocaleData.new(filename, e.inspect)
           end

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -77,7 +77,7 @@ class I18nBackendSimpleTest < I18n::TestCase
 
   test "simple load_json: loads data from a JSON file" do
     data = I18n.backend.send(:load_json, "#{locales_dir}/en.json")
-    assert_equal({ 'en' => { 'foo' => { 'bar' => 'baz' } } }, data)
+    assert_equal({ :en => { :foo => { :bar => 'baz' } } }, data)
   end
 
   test "simple load_translations: loads data from known file formats" do


### PR DESCRIPTION
Will be upstreamed to `ruby-i18n/i18n` but parking here to consolidate feedback from internal reviewers first.