### PR TITLE
Only deep symbolize keys when needed

### DIFF
--- a/lib/i18n/backend/gettext.rb
+++ b/lib/i18n/backend/gettext.rb
@@ -43,7 +43,7 @@ module I18n
         def load_po(filename)
           locale = ::File.basename(filename, '.po').to_sym
           data = normalize(locale, parse(filename))
-          { locale => data }
+          [{ locale => data }, false]
         end
 
         def parse(filename)

--- a/lib/i18n/backend/simple.rb
+++ b/lib/i18n/backend/simple.rb
@@ -40,7 +40,7 @@ module I18n
           end
           locale = locale.to_sym
           translations[locale] ||= Concurrent::Hash.new
-          data = data.deep_symbolize_keys
+          data = data.deep_symbolize_keys unless options.fetch(:skip_symbolize_keys, false)
           translations[locale].deep_merge!(data)
         end
 

--- a/test/backend/simple_test.rb
+++ b/test/backend/simple_test.rb
@@ -66,17 +66,17 @@ class I18nBackendSimpleTest < I18n::TestCase
   end
 
   test "simple load_rb: loads data from a Ruby file" do
-    data = I18n.backend.send(:load_rb, "#{locales_dir}/en.rb")
+    data, _ = I18n.backend.send(:load_rb, "#{locales_dir}/en.rb")
     assert_equal({ :en => { :fuh => { :bah => 'bas' } } }, data)
   end
 
   test "simple load_yml: loads data from a YAML file" do
-    data = I18n.backend.send(:load_yml, "#{locales_dir}/en.yml")
+    data, _ = I18n.backend.send(:load_yml, "#{locales_dir}/en.yml")
     assert_equal({ 'en' => { 'foo' => { 'bar' => 'baz' } } }, data)
   end
 
   test "simple load_json: loads data from a JSON file" do
-    data = I18n.backend.send(:load_json, "#{locales_dir}/en.json")
+    data, _ = I18n.backend.send(:load_json, "#{locales_dir}/en.json")
     assert_equal({ :en => { :foo => { :bar => 'baz' } } }, data)
   end
 
@@ -138,6 +138,20 @@ class I18nBackendSimpleTest < I18n::TestCase
     assert_equal 'foo', I18n.t('1')
     assert_equal 'foo', I18n.t(1)
     assert_equal 'foo', I18n.t(:'1')
+  end
+
+  test "simple store_translations: store translations doesn't deep symbolize keys if skip_symbolize_keys is true" do
+    data = { :foo => {'bar' => 'barfr', 'baz' => 'bazfr'} }
+
+    # symbolized by default
+    store_translations(:fr, data)
+    assert_equal Hash[:foo, {:bar => 'barfr', :baz => 'bazfr'}], translations[:fr]
+
+    I18n.backend.reload!
+
+    # not deep symbolized when configured
+    store_translations(:fr, data, skip_symbolize_keys: true)
+    assert_equal Hash[:foo, {'bar' => 'barfr', 'baz' => 'bazfr'}], translations[:fr]
   end
 
   # reloading translations

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -45,8 +45,8 @@ class I18n::TestCase < TEST_CASE
     I18n.backend.instance_variable_get(:@translations)
   end
 
-  def store_translations(locale, data)
-    I18n.backend.store_translations(locale, data)
+  def store_translations(locale, data, options = I18n::EMPTY_HASH)
+    I18n.backend.store_translations(locale, data, options)
   end
 
   def locales_dir


### PR DESCRIPTION
This will be upstreamed to `ruby-i18n`, but parking here to consolidate feedback for the approach. I'll move it upstream after we're internally aligned.

Dependent on #1. When https://github.com/ruby-i18n/i18n/pull/583 lands, I'll call `mark_keys_as_symbolized` in the YAML case, too.

When loading certain translations from file, they can be parsed into their Symbol representation. It is wasteful to traverse the entire object graph in these cases.

I've introduce a decorator that is used in all the `load_*` methods. It is used to encapsulate all the relevant information produced when loading translations. For now, it holds information about whether the loaded keys are already symbolized, which is used to configure a parameter in `store_translations`.